### PR TITLE
cimcte template: add cstring include required by GetText_alloc

### DIFF
--- a/generator/cimCTE_template.cpp
+++ b/generator/cimCTE_template.cpp
@@ -2,7 +2,7 @@
 #include "imgui_internal.h"
 #include "./ImGuiColorTextEdit/TextEditor.h"
 #include "cimCTE.h"
-
+#include <cstring>
 
 
 #include "auto_funcs.cpp"


### PR DESCRIPTION
Hi
This seems to be required to compile stuff (`std::strcpy` is defined in cstring header)